### PR TITLE
fix: clear input and masm code before adding new input and masm

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -134,6 +134,8 @@ impl eframe::App for TemplateApp {
                 if trigger_assembly.clicked() {
     
                     let assmebly = create_assembly(&sqrt_number_of_cells, &generations, &front_end_grid);
+                    masm_program_frontend.clear();
+                    inputs_string_frontend.clear();
                     masm_program_frontend.push_str(&assmebly.0);
                     inputs_string_frontend.push_str(&assmebly.1);
     


### PR DESCRIPTION
Small fix to clear generated masm code and stack input before adding new inputs. Currently it appends to the previously generated code if the create assembly button is clicked multiple times.